### PR TITLE
feat(lists): support sets and pauses as setlist items

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "license": "ISC",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
-    "@sentry/node": "^8.0.0",
     "@google-cloud/firestore": "^7.11.0",
     "@google/generative-ai": "^0.24.1",
+    "@sentry/node": "^8.0.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/morgan": "^1.9.9",
@@ -38,6 +38,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.28.5",
     "@eslint/js": "^9.14.0",
+    "@types/jest": "^30.0.0",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
     "babel-jest": "^29.7.0",

--- a/src/lists/components/controller.ts
+++ b/src/lists/components/controller.ts
@@ -1,6 +1,12 @@
 import * as store from "../../store/mongoStore.ts";
 import type { Store } from "../../songs/types/types.ts";
-import type { List } from "../types/types.ts";
+import type { List, ListItem } from "../types/types.ts";
+
+function songIdsFromItems(items: ListItem[]): string[] {
+  return items
+    .filter((it): it is Extract<ListItem, { type: "song" }> => it.type === "song")
+    .map((it) => it.songId);
+}
 
 const LISTS_TABLE = process.env.LISTS_TABLE_NAME || "lists";
 
@@ -45,7 +51,11 @@ export default function (injectedStore?: Store<List>) {
   }
 
   async function upsertList(body: any): Promise<{id: string}> {
-    const result = await selectedStore.upsert(LISTS_TABLE, body);
+    const incoming = { ...body };
+    if (Array.isArray(incoming.items)) {
+      incoming.songs = songIdsFromItems(incoming.items as ListItem[]);
+    }
+    const result = await selectedStore.upsert(LISTS_TABLE, incoming);
     return result;
   }
 
@@ -79,7 +89,16 @@ export default function (injectedStore?: Store<List>) {
     if (!songs.includes(songId)) {
       songs.push(songId);
     }
-    const updated = { ...list, songs };
+    const existingItems = Array.isArray(list.items) ? (list.items as ListItem[]) : null;
+    const updated: List = { ...list, songs };
+    if (existingItems) {
+      const alreadyInItems = existingItems.some(
+        (it) => it.type === "song" && it.songId === songId
+      );
+      updated.items = alreadyInItems
+        ? existingItems
+        : [...existingItems, { type: "song", songId }];
+    }
     await selectedStore.upsert(LISTS_TABLE, updated);
     return updated;
   }

--- a/src/lists/components/routes.ts
+++ b/src/lists/components/routes.ts
@@ -53,6 +53,28 @@ type ListRequest = Request & {
  *                 type: array
  *                 items:
  *                   type: string
+ *                 description: Legacy flat array of song IDs. Derived from `items` when both are sent.
+ *               items:
+ *                 type: array
+ *                 description: Ordered setlist items (songs, set markers, pauses).
+ *                 items:
+ *                   oneOf:
+ *                     - type: object
+ *                       required: [type, songId]
+ *                       properties:
+ *                         type: { type: string, enum: [song] }
+ *                         songId: { type: string }
+ *                     - type: object
+ *                       required: [type, label]
+ *                       properties:
+ *                         type: { type: string, enum: [set] }
+ *                         label: { type: string }
+ *                     - type: object
+ *                       required: [type, minutes]
+ *                       properties:
+ *                         type: { type: string, enum: [pause] }
+ *                         minutes: { type: number }
+ *                         label: { type: string }
  *     responses:
  *       201:
  *         description: List created/updated

--- a/src/lists/components/tests/controller.test.js
+++ b/src/lists/components/tests/controller.test.js
@@ -1,0 +1,186 @@
+import controllerFactory from "../controller.ts";
+import { ListSchema } from "../../types/types.ts";
+
+function makeMockStore(seed = []) {
+  const data = new Map(seed.map((l) => [l.id, l]));
+  return {
+    async list() { return [...data.values()]; },
+    async get(_table, id) { return data.get(id) ?? null; },
+    async upsert(_table, body) {
+      data.set(body.id, body);
+      return { id: body.id };
+    },
+    async query(_table, filter) {
+      if (filter && filter.id) {
+        const hit = data.get(filter.id);
+        return hit ? [hit] : [];
+      }
+      return [...data.values()];
+    },
+    async byUserId() { return []; },
+    async listPublic() { return []; },
+    async byIdsArray() { return []; },
+    async sharedWithUser() { return []; },
+    _data: data,
+  };
+}
+
+const baseList = {
+  id: "list-1",
+  title: "Demo",
+  user_uid: "u1",
+  private: false,
+};
+
+describe("ListSchema", () => {
+  test("accepts a list with mixed items (song, set, pause)", () => {
+    const result = ListSchema.safeParse({
+      ...baseList,
+      items: [
+        { type: "set", label: "Opening" },
+        { type: "song", songId: "s1" },
+        { type: "pause", minutes: 15, label: "Break" },
+        { type: "song", songId: "s2" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects an item with an unknown type", () => {
+    const result = ListSchema.safeParse({
+      ...baseList,
+      items: [{ type: "intermezzo", label: "x" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a pause without minutes", () => {
+    const result = ListSchema.safeParse({
+      ...baseList,
+      items: [{ type: "pause", label: "Break" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts a legacy songs-only payload (no items)", () => {
+    const result = ListSchema.safeParse({
+      ...baseList,
+      songs: ["s1", "s2"],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("upsertList", () => {
+  test("derives songs from items when items is provided", async () => {
+    const store = makeMockStore();
+    const controller = controllerFactory(store);
+
+    await controller.upsertList({
+      ...baseList,
+      items: [
+        { type: "set", label: "Opening" },
+        { type: "song", songId: "s1" },
+        { type: "pause", minutes: 10 },
+        { type: "song", songId: "s2" },
+      ],
+    });
+
+    const stored = store._data.get("list-1");
+    expect(stored.songs).toEqual(["s1", "s2"]);
+    expect(stored.items).toHaveLength(4);
+  });
+
+  test("overwrites incoming songs with values derived from items", async () => {
+    const store = makeMockStore();
+    const controller = controllerFactory(store);
+
+    await controller.upsertList({
+      ...baseList,
+      songs: ["stale-id"],
+      items: [
+        { type: "song", songId: "s1" },
+        { type: "song", songId: "s2" },
+      ],
+    });
+
+    expect(store._data.get("list-1").songs).toEqual(["s1", "s2"]);
+  });
+
+  test("preserves songs as-is for legacy payloads without items", async () => {
+    const store = makeMockStore();
+    const controller = controllerFactory(store);
+
+    await controller.upsertList({
+      ...baseList,
+      songs: ["s1", "s2"],
+    });
+
+    const stored = store._data.get("list-1");
+    expect(stored.songs).toEqual(["s1", "s2"]);
+    expect(stored.items).toBeUndefined();
+  });
+});
+
+describe("addSongToList", () => {
+  test("appends to songs when list has no items field (legacy)", async () => {
+    const store = makeMockStore([{ ...baseList, songs: ["s1"] }]);
+    const controller = controllerFactory(store);
+
+    await controller.addSongToList("list-1", "s2");
+
+    const stored = store._data.get("list-1");
+    expect(stored.songs).toEqual(["s1", "s2"]);
+    expect(stored.items).toBeUndefined();
+  });
+
+  test("appends to both songs and items when list already uses items", async () => {
+    const store = makeMockStore([
+      {
+        ...baseList,
+        songs: ["s1"],
+        items: [
+          { type: "set", label: "Opening" },
+          { type: "song", songId: "s1" },
+        ],
+      },
+    ]);
+    const controller = controllerFactory(store);
+
+    await controller.addSongToList("list-1", "s2");
+
+    const stored = store._data.get("list-1");
+    expect(stored.songs).toEqual(["s1", "s2"]);
+    expect(stored.items).toEqual([
+      { type: "set", label: "Opening" },
+      { type: "song", songId: "s1" },
+      { type: "song", songId: "s2" },
+    ]);
+  });
+
+  test("is idempotent for an already-present song", async () => {
+    const store = makeMockStore([
+      {
+        ...baseList,
+        songs: ["s1"],
+        items: [{ type: "song", songId: "s1" }],
+      },
+    ]);
+    const controller = controllerFactory(store);
+
+    await controller.addSongToList("list-1", "s1");
+
+    const stored = store._data.get("list-1");
+    expect(stored.songs).toEqual(["s1"]);
+    expect(stored.items).toEqual([{ type: "song", songId: "s1" }]);
+  });
+
+  test("throws when the list does not exist", async () => {
+    const store = makeMockStore();
+    const controller = controllerFactory(store);
+
+    await expect(controller.addSongToList("missing", "s1")).rejects.toThrow(
+      /missing/
+    );
+  });
+});

--- a/src/lists/components/tests/controller.test.js
+++ b/src/lists/components/tests/controller.test.js
@@ -4,8 +4,12 @@ import { ListSchema } from "../../types/types.ts";
 function makeMockStore(seed = []) {
   const data = new Map(seed.map((l) => [l.id, l]));
   return {
-    async list() { return [...data.values()]; },
-    async get(_table, id) { return data.get(id) ?? null; },
+    async list() {
+      return [...data.values()];
+    },
+    async get(_table, id) {
+      return data.get(id) ?? null;
+    },
     async upsert(_table, body) {
       data.set(body.id, body);
       return { id: body.id };
@@ -17,10 +21,18 @@ function makeMockStore(seed = []) {
       }
       return [...data.values()];
     },
-    async byUserId() { return []; },
-    async listPublic() { return []; },
-    async byIdsArray() { return []; },
-    async sharedWithUser() { return []; },
+    async byUserId() {
+      return [];
+    },
+    async listPublic() {
+      return [];
+    },
+    async byIdsArray() {
+      return [];
+    },
+    async sharedWithUser() {
+      return [];
+    },
     _data: data,
   };
 }
@@ -180,7 +192,7 @@ describe("addSongToList", () => {
     const controller = controllerFactory(store);
 
     await expect(controller.addSongToList("missing", "s1")).rejects.toThrow(
-      /missing/
+      /missing/,
     );
   });
 });

--- a/src/lists/components/tests/controller.test.ts
+++ b/src/lists/components/tests/controller.test.ts
@@ -1,43 +1,13 @@
 import controllerFactory from "../controller.ts";
 import { ListSchema } from "../../types/types.ts";
+import type { List } from "../../types/types.ts";
+import { makeMockStore } from "./mockStore.ts";
 
-function makeMockStore(seed = []) {
-  const data = new Map(seed.map((l) => [l.id, l]));
-  return {
-    async list() {
-      return [...data.values()];
-    },
-    async get(_table, id) {
-      return data.get(id) ?? null;
-    },
-    async upsert(_table, body) {
-      data.set(body.id, body);
-      return { id: body.id };
-    },
-    async query(_table, filter) {
-      if (filter && filter.id) {
-        const hit = data.get(filter.id);
-        return hit ? [hit] : [];
-      }
-      return [...data.values()];
-    },
-    async byUserId() {
-      return [];
-    },
-    async listPublic() {
-      return [];
-    },
-    async byIdsArray() {
-      return [];
-    },
-    async sharedWithUser() {
-      return [];
-    },
-    _data: data,
-  };
-}
+// Prevent mongoStore from calling connect() at import time, which logs async
+// errors after tests finish ("Cannot log after tests are done").
+jest.mock("../../../store/mongoStore.ts", () => ({}));
 
-const baseList = {
+const baseList: List = {
   id: "list-1",
   title: "Demo",
   user_uid: "u1",
@@ -98,7 +68,7 @@ describe("upsertList", () => {
       ],
     });
 
-    const stored = store._data.get("list-1");
+    const stored = store._data.get("list-1")!;
     expect(stored.songs).toEqual(["s1", "s2"]);
     expect(stored.items).toHaveLength(4);
   });
@@ -116,7 +86,7 @@ describe("upsertList", () => {
       ],
     });
 
-    expect(store._data.get("list-1").songs).toEqual(["s1", "s2"]);
+    expect(store._data.get("list-1")!.songs).toEqual(["s1", "s2"]);
   });
 
   test("preserves songs as-is for legacy payloads without items", async () => {
@@ -128,7 +98,7 @@ describe("upsertList", () => {
       songs: ["s1", "s2"],
     });
 
-    const stored = store._data.get("list-1");
+    const stored = store._data.get("list-1")!;
     expect(stored.songs).toEqual(["s1", "s2"]);
     expect(stored.items).toBeUndefined();
   });
@@ -141,7 +111,7 @@ describe("addSongToList", () => {
 
     await controller.addSongToList("list-1", "s2");
 
-    const stored = store._data.get("list-1");
+    const stored = store._data.get("list-1")!;
     expect(stored.songs).toEqual(["s1", "s2"]);
     expect(stored.items).toBeUndefined();
   });
@@ -161,7 +131,7 @@ describe("addSongToList", () => {
 
     await controller.addSongToList("list-1", "s2");
 
-    const stored = store._data.get("list-1");
+    const stored = store._data.get("list-1")!;
     expect(stored.songs).toEqual(["s1", "s2"]);
     expect(stored.items).toEqual([
       { type: "set", label: "Opening" },
@@ -182,7 +152,7 @@ describe("addSongToList", () => {
 
     await controller.addSongToList("list-1", "s1");
 
-    const stored = store._data.get("list-1");
+    const stored = store._data.get("list-1")!;
     expect(stored.songs).toEqual(["s1"]);
     expect(stored.items).toEqual([{ type: "song", songId: "s1" }]);
   });

--- a/src/lists/components/tests/mockStore.ts
+++ b/src/lists/components/tests/mockStore.ts
@@ -1,0 +1,40 @@
+import type { Store } from "../../../songs/types/types.ts";
+import type { List } from "../../types/types.ts";
+
+export type MockStore = Store<List> & { _data: Map<string, List> };
+
+export function makeMockStore(seed: List[] = []): MockStore {
+  const data = new Map<string, List>(seed.map((l) => [l.id!, l]));
+  return {
+    async list() {
+      return [...data.values()];
+    },
+    async get(_table: string, id: string) {
+      return data.get(id) ?? null;
+    },
+    async upsert(_table: string, body: List & { id: string }) {
+      data.set(body.id, body);
+      return { id: body.id };
+    },
+    async query(_table: string, filter: Record<string, unknown>) {
+      if (filter?.id) {
+        const hit = data.get(filter.id as string);
+        return hit ? [hit] : [];
+      }
+      return [...data.values()];
+    },
+    async byUserId() {
+      return [];
+    },
+    async listPublic() {
+      return [];
+    },
+    async byIdsArray() {
+      return [];
+    },
+    async sharedWithUser() {
+      return [];
+    },
+    _data: data,
+  };
+}

--- a/src/lists/types/types.ts
+++ b/src/lists/types/types.ts
@@ -1,11 +1,36 @@
 import { z } from "zod";
 
+const SongItemSchema = z.object({
+  type: z.literal("song"),
+  songId: z.string(),
+});
+
+const SetItemSchema = z.object({
+  type: z.literal("set"),
+  label: z.string(),
+});
+
+const PauseItemSchema = z.object({
+  type: z.literal("pause"),
+  minutes: z.number(),
+  label: z.string().optional(),
+});
+
+export const ListItemSchema = z.discriminatedUnion("type", [
+  SongItemSchema,
+  SetItemSchema,
+  PauseItemSchema,
+]);
+
+export type ListItem = z.infer<typeof ListItemSchema>;
+
 export const ListSchema = z.looseObject({
   id: z.string().optional(),
   title: z.string(),
   user_uid: z.string(),
   private: z.boolean(),
   songs: z.array(z.string()).optional(),
+  items: z.array(ListItemSchema).optional(),
   band_id: z.string().optional(),
   shared_with: z.array(z.string()).optional(),
   show_date: z.string().optional(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,6 +1624,11 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/diff-sequences@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz#25b0818d3d83f00b9c7b04e069b8810f9014b143"
+  integrity sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==
+
 "@jest/environment@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz"
@@ -1633,6 +1638,13 @@
     "@jest/types" "^29.6.3"
     "@types/node" "*"
     jest-mock "^29.7.0"
+
+"@jest/expect-utils@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-30.3.0.tgz#c45b2da9802ffed33bf43b3e019ddb95e5ad95e8"
+  integrity sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
 
 "@jest/expect-utils@^29.7.0":
   version "29.7.0"
@@ -1661,6 +1673,11 @@
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/get-type/-/get-type-30.1.0.tgz#4fcb4dc2ebcf0811be1c04fd1cb79c2dba431cbc"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
+
 "@jest/globals@^29.7.0":
   version "29.7.0"
   resolved "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz"
@@ -1670,6 +1687,14 @@
     "@jest/expect" "^29.7.0"
     "@jest/types" "^29.6.3"
     jest-mock "^29.7.0"
+
+"@jest/pattern@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/pattern/-/pattern-30.0.1.tgz#d5304147f49a052900b4b853dedb111d080e199f"
+  integrity sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==
+  dependencies:
+    "@types/node" "*"
+    jest-regex-util "30.0.1"
 
 "@jest/reporters@^29.7.0":
   version "29.7.0"
@@ -1700,6 +1725,13 @@
     string-length "^4.0.1"
     strip-ansi "^6.0.0"
     v8-to-istanbul "^9.0.1"
+
+"@jest/schemas@30.0.5":
+  version "30.0.5"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-30.0.5.tgz#7bdf69fc5a368a5abdb49fd91036c55225846473"
+  integrity sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
 
 "@jest/schemas@^29.6.3":
   version "29.6.3"
@@ -1757,6 +1789,19 @@
     pirates "^4.0.4"
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
+
+"@jest/types@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-30.3.0.tgz#cada800d323cb74945c24ac74615fdb312a6c85f"
+  integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
+  dependencies:
+    "@jest/pattern" "30.0.1"
+    "@jest/schemas" "30.0.5"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    "@types/istanbul-reports" "^3.0.4"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.33"
+    chalk "^4.1.2"
 
 "@jest/types@^29.6.3":
   version "29.6.3"
@@ -2309,6 +2354,11 @@
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@sinclair/typebox@^0.34.0":
+  version "0.34.49"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.49.tgz#4f1369234f2ecf693866476c3b2e1b54d2a9d68e"
+  integrity sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==
+
 "@sinonjs/commons@^3.0.0":
   version "3.0.1"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz"
@@ -2461,7 +2511,7 @@
   resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz"
   integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz"
   integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
@@ -2473,12 +2523,20 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^3.0.0":
+"@types/istanbul-reports@^3.0.0", "@types/istanbul-reports@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz"
   integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@^30.0.0":
+  version "30.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-30.0.0.tgz#5e85ae568006712e4ad66f25433e9bdac8801f1d"
+  integrity sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==
+  dependencies:
+    expect "^30.0.0"
+    pretty-format "^30.0.0"
 
 "@types/json-schema@^7.0.15", "@types/json-schema@^7.0.6":
   version "7.0.15"
@@ -2605,7 +2663,7 @@
   resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.2.0.tgz#9b706af96fa06416828842397a70dfbbf1c14ded"
   integrity sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==
 
-"@types/stack-utils@^2.0.0":
+"@types/stack-utils@^2.0.0", "@types/stack-utils@^2.0.3":
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
@@ -2651,6 +2709,13 @@
   version "21.0.3"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
+
+"@types/yargs@^17.0.33":
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.33"
@@ -2739,7 +2804,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^5.0.0:
+ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
@@ -3008,7 +3073,7 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3025,6 +3090,11 @@ ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
+
+ci-info@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
 
 cjs-module-lexer@^1.0.0:
   version "1.4.0"
@@ -3498,6 +3568,18 @@ expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+expect@^30.0.0:
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-30.3.0.tgz#1b82111517d1ab030f3db0cf1b4061c8aa644f61"
+  integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
+  dependencies:
+    "@jest/expect-utils" "30.3.0"
+    "@jest/get-type" "30.1.0"
+    jest-matcher-utils "30.3.0"
+    jest-message-util "30.3.0"
+    jest-mock "30.3.0"
+    jest-util "30.3.0"
+
 express-rate-limit@^8.3.1:
   version "8.3.1"
   resolved "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz"
@@ -3866,7 +3948,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.2.9:
+graceful-fs@^4.2.11, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -4248,6 +4330,16 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
+jest-diff@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-30.3.0.tgz#e0a4c84ef350ffd790ffd5b0016acabeecf5f759"
+  integrity sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==
+  dependencies:
+    "@jest/diff-sequences" "30.3.0"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.3.0"
+
 jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz"
@@ -4320,6 +4412,16 @@ jest-leak-detector@^29.7.0:
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
 
+jest-matcher-utils@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz#d6c739fec1ecd33809f2d2b1348f6ab01d2f2493"
+  integrity sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    jest-diff "30.3.0"
+    pretty-format "30.3.0"
+
 jest-matcher-utils@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz"
@@ -4329,6 +4431,21 @@ jest-matcher-utils@^29.7.0:
     jest-diff "^29.7.0"
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
+
+jest-message-util@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-30.3.0.tgz#4d723544d36890ba862ac3961db52db5b0d1ba39"
+  integrity sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@jest/types" "30.3.0"
+    "@types/stack-utils" "^2.0.3"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
+    pretty-format "30.3.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
 
 jest-message-util@^29.7.0:
   version "29.7.0"
@@ -4345,6 +4462,15 @@ jest-message-util@^29.7.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-mock@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-30.3.0.tgz#e0fa4184a596a6c4fdec53d4f412158418923747"
+  integrity sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    jest-util "30.3.0"
+
 jest-mock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz"
@@ -4358,6 +4484,11 @@ jest-pnp-resolver@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz"
   integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
+
+jest-regex-util@30.0.1:
+  version "30.0.1"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-30.0.1.tgz#f17c1de3958b67dfe485354f5a10093298f2a49b"
+  integrity sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==
 
 jest-regex-util@^29.6.3:
   version "29.6.3"
@@ -4467,6 +4598,18 @@ jest-snapshot@^29.7.0:
     natural-compare "^1.4.0"
     pretty-format "^29.7.0"
     semver "^7.5.3"
+
+jest-util@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-30.3.0.tgz#95a4fbacf2dac20e768e2f1744b70519f2ba7980"
+  integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
 
 jest-util@^29.7.0:
   version "29.7.0"
@@ -5165,6 +5308,11 @@ picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
 pirates@^4.0.4:
   version "4.0.6"
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz"
@@ -5215,6 +5363,15 @@ prettier@^3.3.3:
   version "3.3.3"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
+
+pretty-format@30.3.0, pretty-format@^30.0.0:
+  version "30.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-30.3.0.tgz#e977eed4bcd1b6195faed418af8eac68b9ea1f29"
+  integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
+  dependencies:
+    "@jest/schemas" "30.0.5"
+    ansi-styles "^5.2.0"
+    react-is "^18.3.1"
 
 pretty-format@^29.7.0:
   version "29.7.0"
@@ -5298,7 +5455,7 @@ raw-body@^3.0.0:
     iconv-lite "0.6.3"
     unpipe "1.0.0"
 
-react-is@^18.0.0:
+react-is@^18.0.0, react-is@^18.3.1:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
@@ -5583,7 +5740,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-stack-utils@^2.0.3:
+stack-utils@^2.0.3, stack-utils@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz"
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==


### PR DESCRIPTION
## Summary
- Add `ListItem` discriminated-union (`song` | `set` | `pause`) and an optional `items[]` field on `List`. `pause` items carry `minutes` plus an optional `label`; `set` items carry a `label`.
- `upsertList` derives `songs[]` from `items[]` whenever `items` is present, so legacy clients reading the flat `songs` array keep working with no migration.
- `addSongToList` mirrors new entries into both `songs` and `items` when the list already uses `items`; legacy songs-only lists are untouched.
- Swagger doc on `POST /api/lists` now describes the new `items` field.
- New unit tests cover schema validation (mixed items, unknown type rejection, pause-without-minutes rejection, legacy payload), `upsertList` derivation behaviour, and `addSongToList` mirroring + idempotency.

## Test plan
- [ ] `yarn test --testPathPattern=lists`
- [ ] Manual smoke: `POST /api/lists` with an `items` payload (song + set + pause), then `GET /api/lists/:id` and confirm both `items` and a derived `songs` array come back.
- [ ] Manual smoke: `POST /api/lists/:id/songs` against a list with `items` — confirm both arrays grow; against a legacy list — confirm only `songs` grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)