### PR TITLE
add soundcloudUrl to Song schema and patch allowlist

### DIFF
--- a/src/songs/components/controller.ts
+++ b/src/songs/components/controller.ts
@@ -101,7 +101,7 @@ export default function (selectedStore?: Store<Song>) {
   }
 
   const ALLOWED_PATCH_FIELDS = [
-    'title', 'artist', 'chords-text', 'chordpro', 'tags', 'spotifyUrl', 'youtubeUrl', 'public', 'details'
+    'title', 'artist', 'chords-text', 'chordpro', 'tags', 'spotifyUrl', 'youtubeUrl', 'soundcloudUrl', 'public', 'details'
   ] as const;
 
   async function patchSong(id: string, body: Partial<Song>, uid: string): Promise<{ id: string }> {

--- a/src/songs/components/tests/controller.test.ts
+++ b/src/songs/components/tests/controller.test.ts
@@ -166,6 +166,22 @@ describe("patchSong", () => {
     expect(updated.user_uid).toEqual(OWNER); // Should not be modified
     expect((updated as any).foo).toBeUndefined();
   });
+
+  test("allows patching soundcloudUrl and persists it", async () => {
+    const store = makeMockStore([{ ...baseSong }]);
+    const controller = controllerFactory(store);
+
+    await controller.patchSong(
+      "song-1",
+      { 
+        soundcloudUrl: "https://soundcloud.com/artist/track",
+      },
+      OWNER,
+    );
+
+    const updated = store._data.get("song-1")!;
+    expect(updated.soundcloudUrl).toEqual("https://soundcloud.com/artist/track");
+  });
 });
 
 describe("shareSong / unshareSong", () => {

--- a/src/songs/types/types.ts
+++ b/src/songs/types/types.ts
@@ -68,6 +68,7 @@ export const SongSchema = z.object({
   tags: z.array(z.string()).optional(),
   spotifyUrl: z.string().optional(),
   youtubeUrl: z.string().optional(),
+  soundcloudUrl: z.string().optional(),
   band_id: z.string().optional(),
   shared_with: z.array(z.string()).optional(),
 }).passthrough();

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -39,6 +39,7 @@ const options: swaggerJsdoc.Options = {
             tags: { type: "array", items: { type: "string" }, example: ["rock", "acoustic"] },
             spotifyUrl: { type: "string", example: "https://open.spotify.com/track/..." },
             youtubeUrl: { type: "string", example: "https://www.youtube.com/watch?v=..." },
+            soundcloudUrl: { type: "string", example: "https://soundcloud.com/..." },
             shared_with: { type: "array", items: { type: "string" }, example: ["uid1", "uid2"], description: "Firebase UIDs of collaborators who can view and edit this song" },
           },
           required: ["id", "title", "chords-text"],


### PR DESCRIPTION
Lets PATCH /songs accept the new soundcloudUrl field and documents it on the Zod schema. Pairs with the bandmate-front SoundCloud widget integration.